### PR TITLE
Moved vhost creation to take place prior to user creation

### DIFF
--- a/rabbitmq/permissions.sls
+++ b/rabbitmq/permissions.sls
@@ -1,22 +1,19 @@
 include:
   - rabbitmq.service
 
+{% for vhost in salt.pillar.get('rabbitmq:vhosts', []) %}
+rabbitq_vhost_{{ vhost.name }}_{{ vhost.state }}:
+  rabbitmq_vhost.{{ vhost.state }}:
+    - name: {{ vhost.name }}
+    - require:
+        - service: rabbitmq_service_running
+{% endfor %}
+
 {% for user in salt.pillar.get('rabbitmq:users', []) %}
 rabbitmq_user_{{ user.name }}_{{ user.state }}:
   rabbitmq_user.{{ user.state }}:
     - name: {{ user.name }}
     {% for key, value in user.get('settings', {}).items() %}
-    - {{ key }}: {{ value }}
-    {% endfor %}
-    - require:
-        - service: rabbitmq_service_running
-{% endfor %}
-
-{% for vhost in salt.pillar.get('rabbitmq:vhosts', []) %}
-rabbitq_vhost_{{ vhost.name }}_{{ vhost.state }}:
-  rabbitmq_vhost.{{ vhost.state }}:
-    - name: {{ vhost.name }}
-    {% for key, value in vhost.get('settings', {}).items() %}
     - {{ key }}: {{ value }}
     {% endfor %}
     - require:


### PR DESCRIPTION
Moved vhost creation to take place prior to user creation and removed some options from vhost creation as they have been deprecated. Adding user permissions to a vhost happens in the rabbitmq_user function, however the queue needs to exist before perms can be assigned and given that the vhost settings have been deprecated, the only way to add perms to a vhost is through rabbitmq_user.